### PR TITLE
Remove unneeded commands

### DIFF
--- a/bash/reverse-a-string.md
+++ b/bash/reverse-a-string.md
@@ -10,6 +10,6 @@ tset
 It also works with files.
 
 ```shell
-$ cat Procfile | rev
+$ Procfile rev
 br.amup/gifnoc C- amup cexe eldnub :bew
 ```


### PR DESCRIPTION
This removes `cat` and `|`— the end result is the same whether they are included or not.
